### PR TITLE
fix bug,remove redundant item of the oldList

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -92,6 +92,13 @@ function diff (oldList, newList, key) {
     i++
   }
 
+  //if j is not remove to the end, remove all the rest item
+  var k = 0;
+  while (j++<simulateList.length){
+    remove(k+i);
+    k++;
+  }
+
   function remove (index) {
     var move = {index: index, type: 0}
     moves.push(move)


### PR DESCRIPTION
#1
move arithmetic can`t remove redundant item of the oldList
for example:
var oldList = [{id: "d"}, {id: "e"}, {id: "a"}]
var newList = [{id: "a"}, {id: "d"}, {id: "e"}]
the right result shoule be:
moves: [
     {index: 0, type: 1, item: {id: "a"}}, 
     {index: 3, type: 0}
]
