### PR TITLE
edit readme Usage section where moves.forEach should've been moves.moves.forEach

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var moves = diff(oldList, newList, "id")
 //   {index: 4, type: 1, item: {id: "f"}}
 //  ]
 
-moves.forEach(function(move) {
+moves.moves.forEach(function(move) {
   if (move.type === 0) {
     oldList.splice(move.index, 1) // type 0 is removing
   } else {


### PR DESCRIPTION
`var moves = diff(oldList, newList, "id")` returns an object with `moves` key. 
The `moves.forEach(function(move) {` part in **Usage** is incorrect and needs an additional `.moves`.